### PR TITLE
fix: disable caching for static assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>UniProject - Professional Gantt Chart Manager</title>
-    
-    <link rel="stylesheet" href="styles.css">
+
+    <link rel="stylesheet" href="styles.css?v=1">
 </head>
 <body>
     <!-- Header -->
@@ -254,6 +257,6 @@
     </div>
 
     
-    <script src="app.js"></script>
+    <script src="app.js?v=1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure GitHub Pages fetches fresh assets by disabling caching and adding versioned URLs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aadc7c99b4832ab8f8140c9ffa056c