### PR TITLE
Add basic undo/redo functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
     <!-- Toolbar -->
     <div class="toolbar">
         <div class="toolbar-group">
+            <button class="btn btn-icon" onclick="undo()" title="Undo (Ctrl+Z)">↩️</button>
+            <button class="btn btn-icon" onclick="redo()" title="Redo (Ctrl+Y)">↪️</button>
+        </div>
+        <div class="toolbar-group">
             <button class="btn btn-icon" onclick="addTask()" title="Add Task">➕</button>
             <button class="btn btn-icon" onclick="deleteTask()" title="Delete Task">🗑️</button>
             <button class="btn btn-icon" onclick="duplicateTask()" title="Duplicate Task">📋</button>


### PR DESCRIPTION
## Summary
- add undo/redo history stacks with save and restore helpers
- expose undo/redo via toolbar buttons and keyboard shortcuts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aadf17d6cc832ab4b563786bd9eca7