### PR TITLE
Show header actions with mobile menu toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,8 +151,13 @@ function setupEventListeners() {
 
     const menuToggle = document.getElementById('menuToggle');
     if (menuToggle) {
+        const toolbar = document.querySelector('.toolbar');
+        const headerActions = document.querySelector('.header-actions');
         menuToggle.addEventListener('click', () => {
-            document.querySelector('.toolbar').classList.toggle('open');
+            toolbar.classList.toggle('open');
+            if (headerActions) {
+                headerActions.classList.toggle('open');
+            }
         });
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -655,6 +655,12 @@ body {
 
     .header-actions {
         display: none;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .header-actions.open {
+        display: flex;
     }
 
     .btn {


### PR DESCRIPTION
## Summary
- Display header action buttons when the mobile menu is toggled
- Style mobile header actions for wrapping and spacing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aae8a944e0832ab0a8cb33fe928ca5