### PR TITLE
Fix Vitest task test for Frappe demo page

### DIFF
--- a/test/tasks.test.js
+++ b/test/tasks.test.js
@@ -1,17 +1,20 @@
-const fs = require('fs');
-const assert = require('assert');
+import fs from 'fs';
+import { test, expect } from 'vitest';
 
-// Ensure the demo page includes Frappe Gantt initialization
 const html = fs.readFileSync('frappe-demo.html', 'utf8');
-assert(html.includes('new Gantt'), 'Frappe Gantt initialization not found');
 
-// Extract tasks array from the demo page
-const match = html.match(/const tasks = \[(.*?)\];/s);
-assert(match, 'tasks array not found in demo page');
-const tasks = eval('[' + match[1] + ']');
+test('Frappe demo page contains task data and Gantt initialisation', () => {
+  // Ensure the demo page includes Frappe Gantt initialisation
+  expect(html).toContain('new Gantt');
 
-// Basic assertions about task structure
-assert(Array.isArray(tasks) && tasks.length >= 2, 'expected at least two tasks');
-assert(tasks.every(t => t.id && t.name), 'each task should have id and name');
+  // Extract tasks array from the demo page
+  const match = html.match(/const tasks = \[(.*?)\];/s);
+  expect(match).toBeTruthy();
+  const tasks = eval('[' + match[1] + ']');
 
-console.log('Frappe demo page contains task data and Gantt initialization.');
+  // Basic assertions about task structure
+  expect(Array.isArray(tasks)).toBe(true);
+  expect(tasks.length).toBeGreaterThanOrEqual(2);
+  expect(tasks.every(t => t.id && t.name)).toBe(true);
+});
+


### PR DESCRIPTION
## Summary
- convert Frappe demo check into a proper Vitest test
- verify tasks array and Gantt initialisation exist in the demo page

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68abcf897510832ab24eccb83c4591ca