### PR TITLE
feat: add settings modal and calendar features

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,6 @@
       </form>
     </dialog>
 
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -364,6 +364,39 @@ body {
   gap: var(--sp-2);
 }
 
+/* Calendar highlighting */
+.non-working {
+  background: var(--muted);
+}
+
+.day-bg-row {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  display: flex;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.day-bg-row > div {
+  height: 100%;
+}
+
+.day-bg-row > div.non-working {
+  background: var(--muted);
+}
+
+.today-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--primary);
+  pointer-events: none;
+  z-index: 2;
+}
+
 .gantt-header {
   border-bottom: 1px solid var(--border);
   background: var(--surface);


### PR DESCRIPTION
## Summary
- add configurable working days, date format, hours per day and today line toggle
- autosave project settings and state to localStorage
- shade non-working days and draw today line on Gantt chart

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68abd9a79b18832a844425b147f3398b