### PR TITLE
refactor: extract state helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -7,8 +7,8 @@
 
 /* global document */
 
-// Constants
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
+// Shared state helpers
+import { MS_PER_DAY, defaultSettings, createProject } from './src/state.js';
 
 // Project state. Tasks are stored as plain objects with the following
 // properties:
@@ -23,22 +23,8 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 // level: integer indent level (0 = top level)
 // isSummary: boolean indicating summary row
 // expanded: boolean controlling whether children are visible
-function defaultSettings() {
-  return {
-    workingDays: [1, 2, 3, 4, 5],
-    hoursPerDay: 8,
-    dateFormat: 'yyyy-MM-dd',
-    showToday: true
-  };
-}
 
-let project = {
-  name: 'New Project',
-  startDate: new Date(),
-  tasks: [],
-  nextId: 1,
-  settings: defaultSettings()
-};
+let project = createProject();
 
 // UI state
 let selectedTaskId = null;
@@ -813,7 +799,7 @@ function escapeCsv(str) {
 /** Reset project to a clean state. */
 function newProject() {
   if (!confirm('Discard current project and start a new one?')) return;
-  project = { name: 'New Project', startDate: new Date(), tasks: [], nextId: 1, settings: defaultSettings() };
+  project = createProject();
   selectedTaskId = null;
   saveState();
   renderAll();

--- a/src/state.js
+++ b/src/state.js
@@ -1,0 +1,29 @@
+// Centralised application state and defaults for the Gantt chart app.
+// This module exposes helpers used across the codebase so that other
+// modules can construct new project objects and access common constants.
+
+// Number of milliseconds in a day. Exported for scheduling calculations.
+export const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Provide default project settings. These mirror Microsoft Project's
+// defaults and are reused whenever a new project is created.
+export function defaultSettings() {
+  return {
+    workingDays: [1, 2, 3, 4, 5],
+    hoursPerDay: 8,
+    dateFormat: 'yyyy-MM-dd',
+    showToday: true
+  };
+}
+
+// Create a fresh project object with initial values. This helper is used
+// by the application to initialise state and when starting a new project.
+export function createProject() {
+  return {
+    name: 'New Project',
+    startDate: new Date(),
+    tasks: [],
+    nextId: 1,
+    settings: defaultSettings()
+  };
+}


### PR DESCRIPTION
## Summary
- add `src/state.js` with reusable project defaults
- consume state helpers in `app.js` to prepare modular architecture
- ignore `node_modules` in version control

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68abef6f2f54832abc8cd816204ba924