### PR TITLE
feat: initialise UI with toolbar and grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,13 @@
   <title>Gantt Chart App</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
-<body>
-  <div id="toolbar" role="toolbar" aria-label="Project commands"></div>
-  <div id="grid" role="grid" aria-label="Task grid"></div>
-  <div id="gantt" aria-label="Gantt chart"></div>
-  <script type="module" src="src/main.js"></script>
-</body>
+  <body>
+    <div id="toolbar" role="toolbar" aria-label="Project commands"></div>
+    <div class="main-container">
+      <div id="grid" class="task-panel" role="grid" aria-label="Task grid"></div>
+      <div class="panel-resizer"></div>
+      <div id="gantt" class="gantt-panel" aria-label="Gantt chart"></div>
+    </div>
+    <script type="module" src="src/main.js"></script>
+  </body>
 </html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,35 @@
-import { project } from './state.js';
+import { project, loadProject, saveProject } from './state.js';
 import { renderGrid } from './renderGrid.js';
 import { renderGantt } from './renderGantt.js';
 import { schedule } from './schedule.js';
 import { initInteractions } from './interactions.js';
+import { renderToolbar } from './renderToolbar.js';
 
 // Entry point for the application. Render the grid and gantt once the DOM is ready.
 
 document.addEventListener('DOMContentLoaded', () => {
+  loadProject();
+  if (project.tasks.length === 0) {
+    project.tasks.push({
+      id: project.nextId++,
+      level: 0,
+      name: 'New Task',
+      mode: 'auto',
+      duration: { v: 1, u: 'd' },
+      start: project.startDate,
+      finish: null,
+      predecessors: [],
+      percentComplete: 0,
+      constraint: null,
+      notes: '',
+      isSummary: false
+    });
+    saveProject();
+  }
+  const toolbar = document.getElementById('toolbar');
   const grid = document.getElementById('grid');
   const gantt = document.getElementById('gantt');
+  if (toolbar) renderToolbar(toolbar);
   schedule(project.tasks);
   if (grid) renderGrid(grid, project.tasks);
   if (gantt) renderGantt(gantt, project.tasks);

--- a/src/renderGrid.js
+++ b/src/renderGrid.js
@@ -11,19 +11,91 @@ export function updateWBS(tasks) {
   });
 }
 
+export let selectedTaskId = null;
+
+export function getSelectedTaskIndex(tasks) {
+  return tasks.findIndex(t => t.id === selectedTaskId);
+}
+
+export function setSelectedTask(id) {
+  selectedTaskId = id;
+}
+
 export function filterTasks(tasks, query) {
   if (!query) return tasks;
   const q = query.toLowerCase();
   return tasks.filter(t => `${t.id}`.includes(q) || t.name.toLowerCase().includes(q));
 }
 
+function formatDate(d) {
+  return d ? new Date(d).toLocaleDateString('en-AU') : '';
+}
+
 export function renderGrid(container, tasks) {
   container.innerHTML = '';
   updateWBS(tasks);
+
+  const header = document.createElement('div');
+  header.className = 'task-header';
+  const cols = [
+    'Mode',
+    'ID',
+    'WBS',
+    'Name',
+    'Duration',
+    'Start',
+    'Finish',
+    'Predecessors',
+    '% complete',
+    'Constraint',
+    'Notes'
+  ];
+  cols.forEach(text => {
+    const cell = document.createElement('div');
+    cell.textContent = text;
+    header.appendChild(cell);
+  });
+  container.appendChild(header);
+
+  const list = document.createElement('div');
+  list.className = 'task-list';
+
   tasks.forEach(t => {
     const row = document.createElement('div');
-    row.setAttribute('role', 'row');
-    row.textContent = `${t.id} ${t.wbs} ${t.name}`;
-    container.appendChild(row);
+    row.className = 'task-row';
+    if (t.id === selectedTaskId) row.classList.add('selected');
+    if (t.critical) row.classList.add('critical');
+    if (t.isSummary) row.classList.add('summary');
+
+    const cells = [
+      { class: 'task-mode', text: t.mode === 'manual' ? 'M' : 'A' },
+      { class: 'task-id', text: t.id },
+      { class: 'task-wbs', text: t.wbs },
+      { class: 'task-name', text: t.name, indent: t.level },
+      { class: 'task-duration', text: `${t.duration?.v ?? ''}${t.duration?.u ?? ''}` },
+      { class: 'task-start', text: formatDate(t.start || t.ES) },
+      { class: 'task-finish', text: formatDate(t.finish || t.EF) },
+      { class: 'task-predecessors', text: (t.predecessors || []).map(p => p.id).join(', ') },
+      { class: 'task-progress', text: t.percentComplete },
+      { class: 'task-constraint', text: t.constraint?.type || '' },
+      { class: 'task-notes', text: t.notes }
+    ];
+
+    cells.forEach(c => {
+      const cell = document.createElement('div');
+      cell.className = c.class;
+      if (c.indent) cell.style.paddingLeft = `${c.indent * 20}px`;
+      cell.textContent = c.text ?? '';
+      row.appendChild(cell);
+    });
+
+    row.addEventListener('click', () => {
+      setSelectedTask(t.id);
+      renderGrid(container, tasks);
+    });
+
+    list.appendChild(row);
   });
+
+  container.appendChild(list);
 }

--- a/src/renderToolbar.js
+++ b/src/renderToolbar.js
@@ -1,0 +1,159 @@
+import { project, saveProject } from './state.js';
+import { renderGrid, getSelectedTaskIndex, setSelectedTask } from './renderGrid.js';
+import { renderGantt } from './renderGantt.js';
+import { schedule } from './schedule.js';
+
+function refresh() {
+  schedule(project.tasks);
+  const grid = document.getElementById('grid');
+  const gantt = document.getElementById('gantt');
+  if (grid) renderGrid(grid, project.tasks);
+  if (gantt) renderGantt(gantt, project.tasks);
+  saveProject();
+}
+
+function refreshHierarchy() {
+  project.tasks.forEach((t, i) => {
+    const next = project.tasks[i + 1];
+    t.isSummary = next ? next.level > t.level : false;
+  });
+}
+
+function addTask() {
+  const idx = getSelectedTaskIndex(project.tasks);
+  const level = idx >= 0 ? project.tasks[idx].level : 0;
+  const task = {
+    id: project.nextId++,
+    level,
+    name: 'New Task',
+    mode: 'auto',
+    duration: { v: 1, u: 'd' },
+    start: project.startDate,
+    finish: null,
+    predecessors: [],
+    percentComplete: 0,
+    constraint: null,
+    notes: '',
+    isSummary: false
+  };
+  if (idx >= 0) {
+    project.tasks.splice(idx + 1, 0, task);
+  } else {
+    project.tasks.push(task);
+  }
+  setSelectedTask(task.id);
+  refreshHierarchy();
+  refresh();
+}
+
+function deleteTask() {
+  const idx = getSelectedTaskIndex(project.tasks);
+  if (idx >= 0) {
+    project.tasks.splice(idx, 1);
+    setSelectedTask(null);
+    refreshHierarchy();
+    refresh();
+  }
+}
+
+function indentTask() {
+  const idx = getSelectedTaskIndex(project.tasks);
+  if (idx > 0) {
+    const task = project.tasks[idx];
+    const prev = project.tasks[idx - 1];
+    task.level = Math.min(task.level + 1, prev.level + 1);
+    refreshHierarchy();
+    refresh();
+  }
+}
+
+function outdentTask() {
+  const idx = getSelectedTaskIndex(project.tasks);
+  if (idx >= 0) {
+    const task = project.tasks[idx];
+    task.level = Math.max(0, task.level - 1);
+    refreshHierarchy();
+    refresh();
+  }
+}
+
+function moveUp() {
+  const idx = getSelectedTaskIndex(project.tasks);
+  if (idx > 0) {
+    const [task] = project.tasks.splice(idx, 1);
+    project.tasks.splice(idx - 1, 0, task);
+    refreshHierarchy();
+    refresh();
+  }
+}
+
+function moveDown() {
+  const idx = getSelectedTaskIndex(project.tasks);
+  if (idx >= 0 && idx < project.tasks.length - 1) {
+    const [task] = project.tasks.splice(idx, 1);
+    project.tasks.splice(idx + 1, 0, task);
+    refreshHierarchy();
+    refresh();
+  }
+}
+
+const stub = label => () => console.log(label + ' clicked');
+
+export function renderToolbar(container) {
+  container.className = 'toolbar';
+  const right = document.createElement('div');
+  right.className = 'toolbar-right';
+
+  const groups = [
+    {
+      buttons: [
+        { label: 'New Project', onClick: stub('New Project') },
+        { label: 'Open', onClick: stub('Open') },
+        { label: 'Save', onClick: saveProject },
+        { label: 'Export', onClick: stub('Export') }
+      ]
+    },
+    {
+      buttons: [
+        { label: 'Add Task', onClick: addTask },
+        { label: 'Delete Task', onClick: deleteTask },
+        { label: 'Indent', onClick: indentTask },
+        { label: 'Outdent', onClick: outdentTask },
+        { label: 'Move Up', onClick: moveUp },
+        { label: 'Move Down', onClick: moveDown }
+      ]
+    },
+    {
+      buttons: [
+        { label: 'Link Tasks', onClick: stub('Link Tasks') },
+        { label: 'Unlink Tasks', onClick: stub('Unlink Tasks') },
+        { label: 'Auto Schedule', onClick: stub('Auto Schedule') },
+        { label: 'Set Milestone', onClick: stub('Set Milestone') },
+        { label: 'Toggle Critical Path', onClick: stub('Toggle Critical Path') }
+      ]
+    },
+    {
+      buttons: [
+        { label: 'Zoom In', onClick: stub('Zoom In') },
+        { label: 'Zoom Out', onClick: stub('Zoom Out') },
+        { label: 'Settings', onClick: stub('Settings') }
+      ]
+    }
+  ];
+
+  groups.forEach(g => {
+    const groupEl = document.createElement('div');
+    groupEl.className = 'group';
+    g.buttons.forEach(b => {
+      const btn = document.createElement('button');
+      btn.className = 'btn';
+      btn.type = 'button';
+      btn.textContent = b.label;
+      btn.addEventListener('click', b.onClick);
+      groupEl.appendChild(btn);
+    });
+    right.appendChild(groupEl);
+  });
+
+  container.appendChild(right);
+}

--- a/src/state.js
+++ b/src/state.js
@@ -16,3 +16,30 @@ export const project = {
   },
   baseline0: null
 };
+
+const STORAGE_KEY = 'gantt-project';
+
+export function saveProject() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(project));
+  } catch (e) {
+    // Ignore write errors (e.g., storage unavailable)
+  }
+}
+
+export function loadProject() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const data = JSON.parse(raw);
+    Object.assign(project, data);
+    project.startDate = data.startDate ? new Date(data.startDate) : new Date();
+    project.tasks = (data.tasks || []).map(t => ({
+      ...t,
+      start: t.start ? new Date(t.start) : null,
+      finish: t.finish ? new Date(t.finish) : null
+    }));
+  } catch (e) {
+    // Ignore parse errors and keep defaults
+  }
+}


### PR DESCRIPTION
## Summary
- add persistent state helpers and project bootstrap
- implement toolbar with task management actions
- render task grid using CSS layout and main container structure

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac91a35d0c832a9c769c3c8f27af43